### PR TITLE
chore: update deps and add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,21 +9,25 @@
   "keywords": [],
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.mikealrogers.com)",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mikeal/dag-cbor-links.git"
+  },
   "dependencies": {
     "cids": "^0.8.0",
-    "ipld-dag-cbor": "^0.15.2"
+    "ipld-dag-cbor": "^0.16.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.0.1",
-    "eslint-config-standard": "^11.0.0",
+    "eslint": "^7.5.0",
+    "eslint-config-standard": "^14.1.1",
     "eslint-config-standard-babel": "0.0.2",
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "tap": "^12.0.1"
+    "tap": "^14.10.8"
   },
   "eslintConfig": {
     "parser": "babel-eslint",


### PR DESCRIPTION
Upgrades to the latest ipld-dag-cbor module and adds a repository field so people know where this module came from when browsing npm.