### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "url": "git://github.com/mikeal/dag-cbor-links.git"
   },
   "dependencies": {
-    "cids": "^0.8.0",
-    "ipld-dag-cbor": "^0.16.0"
+    "cids": "^1.0.0",
+    "ipld-dag-cbor": "^0.17.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
BREAKING CHANGES:

- The CID class from the `cids` module has had the `.buffer` property
  renamed to `.bytes` so will not work with older module versions.