### PR TITLE
chore!: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "cids": "^1.0.0",
-    "ipld-dag-cbor": "^0.17.0"
+    "ipld-dag-cbor": "^1.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
Pulls in the latest ipld-dag-cbor to get the latest borc to get the
latest buffer.  Ugh.

BREAKING CHANGE: buffer@6 removes support for IE and Safari < 10